### PR TITLE
Bugfix: Last external .srt subtitle entry is not shown.

### DIFF
--- a/src/video/ext_subtitles.c
+++ b/src/video/ext_subtitles.c
@@ -254,6 +254,7 @@ load_srt(const char *url, const char *buf, size_t len, int force_utf8)
   }
 
   if(txt != NULL && pstart != -1 && pstop != -1) {
+    txtoff = tlen - 1;
     txt[txtoff] = 0;
     es_insert_text(es, txt, pstart, pstop, 1);
   }


### PR DESCRIPTION
Hi, I've fixed a small bug were last external .srt subtitle entry is not shown.
Regards.