### PR TITLE
Fix build errors

### DIFF
--- a/src/db/db_support.c
+++ b/src/db/db_support.c
@@ -355,8 +355,8 @@ db_open(const char *path, int flags)
     db_one_statement(db, "PRAGMA case_sensitive_like=1", path);
   db_one_statement(db, "PRAGMA foreign_keys=1", path);
 
-  int freelist_count;
-  int page_count;
+  int freelist_count = 0;
+  int page_count = 0;
 
   db_get_int_from_query(db, "PRAGMA freelist_count", &freelist_count);
   db_get_int_from_query(db, "PRAGMA page_count",     &page_count);


### PR DESCRIPTION
Very small modifications allowing me to build showtime on debian sid.

Here is the build output before modification:
```
In file included from /home/pinchal/showtime/src/db/db_support.c:23:0:
/home/pinchal/showtime/src/db/db_support.c: In function ‘db_open’:
/home/pinchal/showtime/src/showtime.h:124:43: error: ‘page_count’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define TRACE(level, subsys, fmt...) trace(0, level, subsys, fmt)
                                           ^
/home/pinchal/showtime/src/db/db_support.c:359:7: note: ‘page_count’ was declared here
   int page_count;
       ^
In file included from /home/pinchal/showtime/src/db/db_support.c:23:0:
/home/pinchal/showtime/src/showtime.h:124:43: error: ‘freelist_count’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 #define TRACE(level, subsys, fmt...) trace(0, level, subsys, fmt)
                                           ^
/home/pinchal/showtime/src/db/db_support.c:358:7: note: ‘freelist_count’ was declared here
   int freelist_count;
       ^
cc1: all warnings being treated as errors
```