### PR TITLE
htsp: #2206 Do the same thing for list view also.

### DIFF
--- a/glwskins/default/pages/list.view
+++ b/glwskins/default/pages/list.view
@@ -26,7 +26,8 @@ widget(keyintercept, {
 	  &clone.focused = focusedChild();
 	  spacing: 3;
 
-	  cloner($page.model.nodes, loader, {
+	  cloner(propSorter($page.model.nodes,
+                      sort, "node.metadata.channelNumber", false, false), loader, {
 	    time: 0.1;
 	    effect: blend;
 	    alt: "listitems/default.view";


### PR DESCRIPTION
Notes:

I'm not sure in javascript how to apply this poperty sorting criteria only for sources of type

			  "tvchannel", "iteminfo/tvchannel.view",

However this change was tested in my own custom OS X build and it does not seem to break other list regular views which are not of the `tvchannel` type.

@andoma  I need you to pls merge upstream since I can't compile for PS3 architecture myself. Many thanks.