### PR TITLE
ecmascript/prop.js: proxy setter must return true

### DIFF
--- a/resources/ecmascript/modules/showtime/prop.js
+++ b/resources/ecmascript/modules/showtime/prop.js
@@ -36,12 +36,12 @@ var propHandler = {
 
       if('toRichString' in value) {
         np.setRichStr(obj, name, value.toRichString());
-        return;
+        return true;
       }
 
       if(np.isValue(value)) {
         np.set(obj, name, np.getValue(value));
-        return;
+        return true;
       }
 
       var x = np.getChild(obj, name);
@@ -55,6 +55,7 @@ var propHandler = {
     } else {
       np.set(obj, name, value);
     }
+    return true;
   },
 
   enumerate: np.enumerate,


### PR DESCRIPTION
Duktape raises TypeError exception when strict mode is enabled and setter
provided by Proxy handler doesn't return true (because returning `true`
indicates that property write was allowed).

Relevant Duktape test is [here](https://github.com/svaarala/duktape/blob/ba930541dcfb149598889abcec6770851696bd79/ecmascript-testcases/test-bi-proxy-get-set-deleteproperty.js#L191).